### PR TITLE
Replace deprecated cloud.gov deployment GitHub Action

### DIFF
--- a/lib/generators/rails_template18f/github_actions/templates/github/workflows/deploy-production.yml.tt
+++ b/lib/generators/rails_template18f/github_actions/templates/github/workflows/deploy-production.yml.tt
@@ -49,5 +49,5 @@ jobs:
           cf_username: ${{ secrets.CF_USERNAME }}
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: <%= cloud_gov_organization %>
-          cf_space: <%= cloud_gov_staging_space %>
-          cf_command: push -vars-file config/deployment/staging.yml --var rails_master_key=${{ env.RAILS_MASTER_KEY }} --strategy rolling
+          cf_space: <%= cloud_gov_production_space %>
+          cf_command: push -vars-file config/deployment/production.yml --var rails_master_key=${{ env.RAILS_MASTER_KEY }} --strategy rolling

--- a/lib/generators/rails_template18f/github_actions/templates/github/workflows/deploy-production.yml.tt
+++ b/lib/generators/rails_template18f/github_actions/templates/github/workflows/deploy-production.yml.tt
@@ -42,14 +42,12 @@ jobs:
         run: terraform apply -auto-approve -input=false
       <% end %>
       - name: Deploy app
-        uses: 18F/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         env:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
         with:
           cf_username: ${{ secrets.CF_USERNAME }}
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: <%= cloud_gov_organization %>
-          cf_space: <%= cloud_gov_production_space %>
-          push_arguments: >-
-            --vars-file config/deployment/production.yml
-            --var rails_master_key=$RAILS_MASTER_KEY
+          cf_space: <%= cloud_gov_staging_space %>
+          cf_command: push -vars-file config/deployment/staging.yml --var rails_master_key=${{ env.RAILS_MASTER_KEY }} --strategy rolling

--- a/lib/generators/rails_template18f/github_actions/templates/github/workflows/deploy-staging.yml.tt
+++ b/lib/generators/rails_template18f/github_actions/templates/github/workflows/deploy-staging.yml.tt
@@ -42,7 +42,7 @@ jobs:
         run: terraform apply -auto-approve -input=false
       <% end %>
       - name: Deploy app
-        uses: 18F/cg-deploy-action@main
+        uses: cloud-gov/cg-cli-tools@main
         env:
           RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
         with:
@@ -50,6 +50,4 @@ jobs:
           cf_password: ${{ secrets.CF_PASSWORD }}
           cf_org: <%= cloud_gov_organization %>
           cf_space: <%= cloud_gov_staging_space %>
-          push_arguments: >-
-            --vars-file config/deployment/staging.yml
-            --var rails_master_key=$RAILS_MASTER_KEY
+          cf_command: push -vars-file config/deployment/staging.yml --var rails_master_key=${{ env.RAILS_MASTER_KEY }} --strategy rolling


### PR DESCRIPTION
`18f/cg-deploy-action` is deprecated and unmaintained. It's also dependent on the availability of `packages.cloudfoundry.org`, [which is not always up](https://gsa-tts.slack.com/archives/C09CR1Q9Z/p1700058746739689). The `cloud-gov/cg-cli-tools` action, by contrast, is offered and supported by cloud.gov, and does not have that dependency. Find out more about it here:
https://github.com/cloud-gov/cg-cli-tools