### PR TITLE
Use USWDS Language Selector component

### DIFF
--- a/lib/generators/rails_template18f/i18n/i18n_generator.rb
+++ b/lib/generators/rails_template18f/i18n/i18n_generator.rb
@@ -36,6 +36,7 @@ module RailsTemplate18f
       end
 
       def install_translations
+        app_name # reference app_name here so the instance var is set before entering the "inside" block
         inside "config/locales" do
           template "en.yml"
           languages.each do |lang|

--- a/lib/generators/rails_template18f/i18n/i18n_generator.rb
+++ b/lib/generators/rails_template18f/i18n/i18n_generator.rb
@@ -56,12 +56,12 @@ module RailsTemplate18f
 
       def install_nav_helper
         inject_into_module "app/helpers/application_helper.rb", "ApplicationHelper", indent(<<~'EOH')
-          def format_active_locale(locale_string)
-            link_classes = "usa-nav__link"
-            if locale_string.to_sym == I18n.locale
-              link_classes = "#{link_classes} usa-current"
-            end
-            link_to t("shared.languages.#{locale_string}"), root_path(locale: locale_string), class: link_classes
+          def active_locale?(locale_string)
+            locale_string.to_sym == I18n.locale
+          end
+
+          def language_span(locale_string)
+            content_tag :span, t("shared.languages.#{locale_string}"), lang: locale_string, "xml:lang": locale_string
           end
         EOH
       end

--- a/lib/generators/rails_template18f/i18n/templates/config/locales/en.yml.tt
+++ b/lib/generators/rails_template18f/i18n/templates/config/locales/en.yml.tt
@@ -21,5 +21,6 @@ en:
       en: English
       es: Español
       fr: Français
+      selector: Languages
       zh: 中文
     skip_link: Skip to main content

--- a/lib/generators/rails_template18f/i18n/templates/config/locales/es.yml
+++ b/lib/generators/rails_template18f/i18n/templates/config/locales/es.yml
@@ -16,4 +16,6 @@ es:
       demo_banner: SITIO DE PRUEBA - No utilice información personal real (sólo para propósitos de demostración) - SITIO DE PRUEBA
       menu: Menú
       primary: Navegacion primaria
+    languages:
+      selector: Idiomas
     skip_link: Salte al contenido principal

--- a/lib/generators/rails_template18f/i18n/templates/config/locales/fr.yml
+++ b/lib/generators/rails_template18f/i18n/templates/config/locales/fr.yml
@@ -16,4 +16,6 @@ fr:
       demo_banner: SITE DE TEST - N’utilisez pas de véritables données personnelles (il s’agit d’une démonstration seulement) - SITE DE TEST
       menu: Menu
       primary: Navigation primaire
+    languages:
+      selector: Langages
     skip_link: Passer au contenu principal

--- a/lib/generators/rails_template18f/i18n/templates/config/locales/zh.yml
+++ b/lib/generators/rails_template18f/i18n/templates/config/locales/zh.yml
@@ -13,4 +13,6 @@ zh:
       us_flag: 美国国旗
     header:
       primary: 主导航
+    languages:
+      selector: 语言
     skip_link: 跳转到主要内容

--- a/spec/generators/rails_template18f/i18n/i18n_generator_spec.rb
+++ b/spec/generators/rails_template18f/i18n/i18n_generator_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe RailsTemplate18f::Generators::I18nGenerator, type: :generator do
       expect(file("config/locales/zh.yml")).to exist
     end
 
+    it "sets the correct header title" do
+      expect(file("config/locales/en.yml")).to contain "title: Tmp"
+    end
+
     it "adds routing code, helper, and around_action" do
       expect(file("config/routes.rb")).to contain("scope \"(:locale)\"")
       expect(file("app/helpers/application_helper.rb")).to contain("def language_span(locale_string)")

--- a/spec/generators/rails_template18f/i18n/i18n_generator_spec.rb
+++ b/spec/generators/rails_template18f/i18n/i18n_generator_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe RailsTemplate18f::Generators::I18nGenerator, type: :generator do
 
     it "adds routing code, helper, and around_action" do
       expect(file("config/routes.rb")).to contain("scope \"(:locale)\"")
-      expect(file("app/helpers/application_helper.rb")).to contain("def format_active_locale(locale_string)")
+      expect(file("app/helpers/application_helper.rb")).to contain("def language_span(locale_string)")
+      expect(file("app/helpers/application_helper.rb")).to contain("def active_locale?(locale_string)")
       expect(file("app/controllers/application_controller.rb")).to contain("around_action :switch_locale")
     end
   end

--- a/template.rb
+++ b/template.rb
@@ -291,8 +291,10 @@ after_bundle do
   end
   directory "app/assets"
   append_to_file "app/assets/stylesheets/application.postcss.css", <<~EOCSS
-    @forward "uswds-settings.scss";
-    @forward "uswds-components.scss";
+    @forward "uswds-settings";
+    @forward "uswds-components";
+
+    @forward "uswds-overrides";
   EOCSS
   inside "app/assets/stylesheets" do
     File.rename("application.postcss.css", "application.postcss.scss")

--- a/templates/app/assets/stylesheets/uswds-components.scss
+++ b/templates/app/assets/stylesheets/uswds-components.scss
@@ -1,7 +1,13 @@
 @forward "uswds-global";
 @forward "uswds-utilities";
 @forward "uswds-typography";
+@forward "usa-layout-grid";
 @forward "usa-header";
 @forward "usa-banner";
 @forward "usa-section";
+@forward "usa-language-selector";
 // add additional packages here as you use them
+
+// or replace these all with
+// @forward "uswds";
+// to import the entirety of uswds

--- a/templates/app/assets/stylesheets/uswds-overrides/_index.scss
+++ b/templates/app/assets/stylesheets/uswds-overrides/_index.scss
@@ -1,0 +1,2 @@
+@forward "override-usa-banner";
+@forward "override-usa-language-selector";

--- a/templates/app/assets/stylesheets/uswds-overrides/_override-usa-banner.scss
+++ b/templates/app/assets/stylesheets/uswds-overrides/_override-usa-banner.scss
@@ -1,0 +1,13 @@
+
+.banner__text-container {
+  flex: 1;
+}
+
+.usa-banner__button {
+  margin-right: 0.5rem;
+}
+
+[dir="rtl"] .usa-banner__header-flag {
+  margin-left: 0.5rem;
+  margin-right: 0;
+}

--- a/templates/app/assets/stylesheets/uswds-overrides/_override-usa-language-selector.scss
+++ b/templates/app/assets/stylesheets/uswds-overrides/_override-usa-language-selector.scss
@@ -1,0 +1,38 @@
+
+.usa-language-container {
+  padding: 0.5rem 1rem;
+}
+
+.usa-language__submenu {
+  padding: 20px;
+  width: auto;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+
+.usa-language__submenu-item {
+  padding: 4px 8px;
+
+  &:last-child {
+    border-bottom: 1px solid #dfe1e2;
+  }
+}
+
+.switcher-desktop {
+  @media (max-width: 800px) {
+    display: none;
+  }
+}
+
+.switcher-mobile {
+  @media (min-width: 800px) {
+    display: none;
+  }
+}
+
+.usa-language__primary-item:last-of-type .usa-language__submenu {
+  [dir="rtl"] & {
+    right: unset;
+    left: 0;
+  }
+}

--- a/templates/app/views/application/_header.html.erb
+++ b/templates/app/views/application/_header.html.erb
@@ -1,5 +1,8 @@
 <div class="usa-overlay"></div>
 <header class="usa-header usa-header--basic">
+  <div class="switcher-mobile">
+    <%= render partial: "application/language_selector", locals: {mode: "mobile"} %>
+  </div>
   <div class="usa-nav-container">
     <div class="usa-navbar">
       <div class="usa-logo">
@@ -14,11 +17,9 @@
         <%= image_tag "@uswds/uswds/dist/img/usa-icons/close.svg", role: "img", alt: t('shared.header.close') %>
       </button>
       <ul class="usa-nav__primary usa-accordion">
-        <% I18n.available_locales.each do |l| %>
-          <li class="usa-nav__primary-item">
-            <%= format_active_locale(l) %>
-          </li>
-        <% end %>
+        <li class="usa-nav__primary-item">
+          <%= link_to "Example Nav Item", root_path %>
+        </li>
       </ul>
     </nav>
   </div>

--- a/templates/app/views/application/_language_selector.html.erb
+++ b/templates/app/views/application/_language_selector.html.erb
@@ -1,0 +1,35 @@
+
+<% if I18n.available_locales.count == 2 %>
+  <% I18n.available_locales.each do |l| %>
+    <% unless active_locale?(l) %>
+      <div class="usa-language-container usa-language--small">
+        <%= link_to language_span(l), root_path(locale: l), class: "usa-button" %>
+      </div>
+    <% end %>
+  <% end %>
+<% elsif I18n.available_locales.count > 2 %>
+  <div class="usa-language-container">
+    <ul class="usa-language__primary usa-accordion">
+      <li class="usa-language__primary-item">
+        <button
+          type="button"
+          class="usa-button usa-language__link"
+          role="button"
+          aria-expanded="false"
+          aria-controls="language-options-<%= mode %>"
+        >
+          <%= t "shared.languages.selector" %>
+        </button>
+        <ul id="language-options-<%= mode %>" class="usa-language__submenu" hidden="true">
+          <% I18n.available_locales.each do |l| %>
+            <% unless active_locale?(l) %>
+              <li class="usa-language__submenu-item">
+                <%= link_to content_tag(:strong, language_span(l)), root_path(locale: l) %>
+              </li>
+            <% end %>
+          <% end %>
+        </ul>
+      </li>
+    </ul>
+  </div>
+<% end %>

--- a/templates/app/views/application/_usa_banner.html.erb
+++ b/templates/app/views/application/_usa_banner.html.erb
@@ -4,24 +4,29 @@
   <div class="usa-accordion">
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
-        <div class="grid-col-auto">
-          <%= image_tag "@uswds/uswds/dist/img/us_flag_small.png", alt: t('shared.banner.us_flag'), class: "usa-banner__header-flag" %>
+        <div class="banner__text-container grid-row">
+          <div class="grid-col-auto">
+            <%= image_tag "@uswds/uswds/dist/img/us_flag_small.png", alt: t('shared.banner.us_flag'), class: "usa-banner__header-flag" %>
+          </div>
+          <div class="grid-col-fill tablet:grid-col-auto">
+            <p class="usa-banner__header-text">
+              <%= t('shared.banner.official_site') %>
+            </p>
+            <p class="usa-banner__header-action" aria-hidden="true">
+              <%= t('shared.banner.how') %>
+            </p>
+          </div>
+          <button
+            class="usa-accordion__button usa-banner__button"
+            aria-expanded="false"
+            aria-controls="gov-banner"
+          >
+            <span class="usa-banner__button-text"><%= t('shared.banner.how') %></span>
+          </button>
         </div>
-        <div class="grid-col-fill tablet:grid-col-auto">
-          <p class="usa-banner__header-text">
-            <%= t('shared.banner.official_site') %>
-          </p>
-          <p class="usa-banner__header-action" aria-hidden="true">
-            <%= t('shared.banner.how') %>
-          </p>
+        <div class="switcher-desktop">
+          <%= render partial: "application/language_selector", locals: {mode: "desktop"} %>
         </div>
-        <button
-          class="usa-accordion__button usa-banner__button"
-          aria-expanded="false"
-          aria-controls="gov-banner"
-        >
-          <span class="usa-banner__button-text"><%= t('shared.banner.how') %></span>
-        </button>
       </div>
     </header>
     <div class="usa-banner__content usa-accordion__content" id="gov-banner">


### PR DESCRIPTION
Followed the design pattern from vote.gov for where to place the component on the page. This seems to work nicely in both desktop and mobile.

closes #62 

Screenshots:

Desktop, menu closed:
<img width="1033" alt="Screenshot 2024-06-13 at 11 20 14 AM" src="https://github.com/GSA-TTS/rails-template/assets/285842/a87ab684-7950-49c7-80af-40e8494af213">

Desktop, menu open:
<img width="1036" alt="Screenshot 2024-06-13 at 11 20 23 AM" src="https://github.com/GSA-TTS/rails-template/assets/285842/0ec853fe-e0c3-4772-9989-f4030097f697">

Mobile, menu closed:
<img width="385" alt="Screenshot 2024-06-13 at 11 23 43 AM" src="https://github.com/GSA-TTS/rails-template/assets/285842/f98f0582-bf48-4a99-b38c-d7e427e0a174">

Mobile, menu open:
<img width="387" alt="Screenshot 2024-06-13 at 11 23 49 AM" src="https://github.com/GSA-TTS/rails-template/assets/285842/c48c5635-ab68-40f2-a4be-d692eb1f0b76">