### PR TITLE
remove nodejs_buildpack to prevent duplicate node_modules

### DIFF
--- a/templates/manifest.yml.tt
+++ b/templates/manifest.yml.tt
@@ -2,7 +2,6 @@
 applications:
 - name: <%= app_name %>-((env))
   buildpacks:
-    - nodejs_buildpack
     - ruby_buildpack
   env:
     RAILS_MASTER_KEY: ((rails_master_key))


### PR DESCRIPTION
The nodejs buildpack was creating a duplicate copy of node_modules and wasting disk space, it is no longer needed after this update to the ruby buildpack https://github.com/cloudfoundry/ruby-buildpack/pull/373 was merged.