### PR TITLE
Add auditree GitHub actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- add an auditree generator for integration with auditree-devtools and github actions to run it
+- remove the obsolete entry to include nodejs_buildpack in cloud.gov manifest.yml
+
 ## [1.0.0] - 2024-06-27
 
 - new applications are now on Rails 7.1.x

--- a/lib/generators/rails_template18f/auditree/auditree_generator.rb
+++ b/lib/generators/rails_template18f/auditree/auditree_generator.rb
@@ -38,7 +38,7 @@ module RailsTemplate18f
 
       def update_component_list
         if oscal_dir_exists?
-          insert_into_file "doc/compliance/oscal/trestle-config.yaml", "  - #{devtools_cloud_gov}\n"
+          insert_into_file "doc/compliance/oscal/trestle-config.yaml", "  - devtools_cloud_gov\n"
         end
       end
 

--- a/lib/generators/rails_template18f/auditree/auditree_generator.rb
+++ b/lib/generators/rails_template18f/auditree/auditree_generator.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require "rails/generators"
+
+module RailsTemplate18f
+  module Generators
+    class AuditreeGenerator < ::Rails::Generators::Base
+      include Base
+
+      class_option :tag, desc: "Which auditree docker tag to use. Defaults to `latest`"
+      class_option :git_email, desc: "Email address to associate with commits to the evidence locker"
+
+      desc <<~DESC
+        Description:
+          Set up auditree validation checking with https://github.com/GSA-TTS/devtools-auditree.
+
+          This generator is still experimental.
+      DESC
+
+      def copy_bin
+        template "bin/auditree"
+        chmod "bin/auditree", 0o755
+      end
+
+      def copy_github_actions
+        if file_exists? ".github/workflows"
+          directory "github", ".github"
+        end
+      end
+
+      def update_readme
+        if file_content("README.md").match?("## Documentation")
+          insert_into_file "README.md", readme_contents, after: "## Documentation\n"
+        else
+          append_to_file "README.md", "\n## Documentation\n#{readme_contents}"
+        end
+      end
+
+      def update_component_list
+        if oscal_dir_exists?
+          insert_into_file "doc/compliance/oscal/trestle-config.yaml", "  - #{devtools_cloud_gov}\n"
+        end
+      end
+
+      no_tasks do
+        def docker_auditree_tag
+          options[:tag].present? ? options[:tag] : "latest"
+        end
+
+        def git_email
+          options[:git_email].present? ? options[:git_email] : "TKTK-email@gsa.gov"
+        end
+
+        def readme_contents
+          <<~README
+
+            ### Auditree Control Validation
+
+            Auditree is used within CI/CD to validate that certain controls are in place.
+
+            * Run `bin/auditree` to start the auditree CLI.
+            * Run `bin/auditree SCRIPT_NAME` to run a single auditree script
+
+            #### Initial auditree setup.
+
+            These steps must happen once per project.
+
+            1. Docker desktop must be running
+            1. Initialize the config file with `bin/auditree init > config/auditree.template.json`
+            1. Create an evidence locker repository with a default or blank README
+            1. Create a github personal access token to interact with the code repo and evidence locker and set as `AUDITREE_GITHUB_TOKEN` secret within your production Github environment secrets.
+            1. Update `config/auditree.template.json` with the repo addresses for your locker and code repos
+            1. Copy the `devtools_cloud_gov` component definition into the project with the latest docker-trestle
+
+            #### Ongoing use
+
+            See the [auditree-devtools README](https://github.com/gsa-tts/auditree-devtools) for help with updating
+            auditree and using new checks.
+          README
+        end
+      end
+    end
+  end
+end

--- a/lib/generators/rails_template18f/auditree/templates/bin/auditree.tt
+++ b/lib/generators/rails_template18f/auditree/templates/bin/auditree.tt
@@ -5,4 +5,4 @@ if [ "$1" != "" ]; then
     command=$1
 fi
 
-docker run -it --rm ghcr.io/gsa-tts/trestle:<%= docker_auditree_tag %> $command
+docker run -it --rm ghcr.io/gsa-tts/auditree:<%= docker_auditree_tag %> $command

--- a/lib/generators/rails_template18f/auditree/templates/bin/auditree.tt
+++ b/lib/generators/rails_template18f/auditree/templates/bin/auditree.tt
@@ -1,0 +1,8 @@
+#! /usr/bin/env bash
+
+command="bash"
+if [ "$1" != "" ]; then
+    command=$1
+fi
+
+docker run -it --rm ghcr.io/gsa-tts/trestle:<%= docker_auditree_tag %> $command

--- a/lib/generators/rails_template18f/auditree/templates/bin/auditree.tt
+++ b/lib/generators/rails_template18f/auditree/templates/bin/auditree.tt
@@ -1,8 +1,29 @@
 #! /usr/bin/env bash
+usage="
+$0: Run auditree docker image.
+
+Usage:
+  $0 -h
+  $0
+  $0 init > path/to/auditree.template.json
+  $0 fetch
+  $0 check > path/to/assessment-results/auditree/assessment-results.json
+
+Notes:
+The following environment variables will be passed through to the docker image:
+* GITHUB_TOKEN - a token that has permissions to read and write to the evidence locker and code repository. Required for all but 'init'
+* CF_USERNAME - the cloud.gov username to fetch evidence from cloud.gov, only needed when running fetch script
+* CF_PASSWORD - the cloud.gov password to fetch evidence from cloud.gov, only needed when running fetch script
+"
+
+if [ "$1" = "-h" ]; then
+    echo "$usage"
+    exit 0
+fi
 
 command="bash"
 if [ "$1" != "" ]; then
     command=$1
 fi
 
-docker run -it --rm ghcr.io/gsa-tts/auditree:<%= docker_auditree_tag %> $command
+docker run -e GITHUB_TOKEN -e CF_USERNAME -e CF_PASSWORD -e GIT_EMAIL="<%= git_email %>" -it --rm ghcr.io/gsa-tts/auditree:<%= docker_auditree_tag %> $command

--- a/lib/generators/rails_template18f/auditree/templates/github/actions/auditree-cmd/action.yml.tt
+++ b/lib/generators/rails_template18f/auditree/templates/github/actions/auditree-cmd/action.yml.tt
@@ -1,0 +1,31 @@
+name: "Run an auditree-devtools command"
+description: "Sets up workspace for running a single command in auditree-devtools"
+inputs:
+  tag:
+    description: auditree-devtools tag to use. Defaults to <%= docker_auditree_tag %>
+    required: false
+    default: <%= docker_auditree_tag %>
+  cmd:
+    description: Command to run within auditree-devtools
+    required: true
+  email:
+    description: Git user email to attribute to evidence updates
+    required: true
+  config_template:
+    description: Auditree config file template
+    required: false
+    default: config/auditree.template.json
+  cdef:
+    description: OSCAL Component Definition being used as baseline for assessment results
+    required: false
+    default: doc/compliance/oscal/component-definitions/devtools_cloud_gov/component-definition.json
+runs:
+  using: "composite"
+  steps:
+    - name: Run cmd
+      shell: bash
+      run:
+        docker run -v $GITHUB_WORKSPACE/${{inputs.config_template}}:/app/auditree.template.json:ro
+          -v $GITHUB_WORKSPACE/${{inputs.cdef}}:/app/cdef.json:ro
+          -e GITHUB_TOKEN -e CF_USERNAME -e CF_PASSWORD -e GIT_EMAIL="${{inputs.email}}"
+          ghcr.io/gsa-tts/auditree:${{ inputs.tag }} ${{ inputs.cmd }}

--- a/lib/generators/rails_template18f/auditree/templates/github/workflows/auditree-validation.yml.tt
+++ b/lib/generators/rails_template18f/auditree/templates/github/workflows/auditree-validation.yml.tt
@@ -1,0 +1,42 @@
+name: Run Auditree Checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    # cron format: 'minute hour dayofmonth month dayofweek'
+    # this will run at 11am UTC every day (6am EST / 7am EDT)
+    - cron: '0 11 * * *'
+
+jobs:
+  run_auditree:
+    name: Fetch and check auditree evidence
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fetch evidence
+        uses: ./.github/actions/auditree-cmd
+        env:
+          CF_USERNAME: ${{ secrets.CF_USERNAME }}
+          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.AUDITREE_GITHUB_TOKEN }}
+        with:
+          cmd: fetch
+          email: "<%= git_email %>"
+
+      - name: Check evidence
+        uses: ./.github/actions/auditree-cmd
+        env:
+          CF_USERNAME: ${{ secrets.CF_USERNAME }}
+          CF_PASSWORD: ${{ secrets.CF_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.AUDITREE_GITHUB_TOKEN }}
+        with:
+          cmd: check > doc/compliance/oscal/assessment-results/auditree/assessment-results.json
+          email: "<%= git_email %>"
+
+      - name: Save results
+        uses: actions/upload-artifact@v4
+        with:
+          name: auditree_assessment_results
+          path: doc/compliance/oscal/assessment-results/auditree

--- a/spec/generators/rails_template18f/auditree/auditree_generator_spec.rb
+++ b/spec/generators/rails_template18f/auditree/auditree_generator_spec.rb
@@ -14,4 +14,8 @@ RSpec.describe RailsTemplate18f::Generators::AuditreeGenerator, type: :generator
     expect(file(".github/actions/auditree-cmd/action.yml")).to exist
     expect(file(".github/workflows/deploy.yml")).to exist
   end
+
+  it "update the trestle-config yaml file to include devtools_cloud_gov" do
+    expect(file("doc/compliance/oscal/trestle-config.yaml")).to contain("  - devtools_cloud_gov")
+  end
 end

--- a/spec/generators/rails_template18f/auditree/auditree_generator_spec.rb
+++ b/spec/generators/rails_template18f/auditree/auditree_generator_spec.rb
@@ -1,0 +1,17 @@
+require "generators/rails_template18f/auditree/auditree_generator"
+
+RSpec.describe RailsTemplate18f::Generators::AuditreeGenerator, type: :generator do
+  setup_github_actions_destination
+
+  subject! { run_generator }
+
+  it "creates a helper script for running auditree" do
+    expect(file("bin/auditree")).to exist
+  end
+
+  it "copies the auditree workflow files without overwriting exiting workflows" do
+    expect(file(".github/workflows/auditree-validation.yml")).to exist
+    expect(file(".github/actions/auditree-cmd/action.yml")).to exist
+    expect(file(".github/workflows/deploy.yml")).to exist
+  end
+end

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -22,6 +22,16 @@ module RailsTemplate18f
           }
         end
 
+        def setup_github_actions_destination
+          destination destination_path
+          before {
+            prepare_destination
+            generate_base_app
+            system "mkdir", "-p", File.join(self.class.destination_path, ".github/workflows")
+            system "touch", File.join(self.class.destination_path, ".github/workflows/deploy.yml")
+          }
+        end
+
         def setup_active_storage_destination
           destination destination_path
           before {
@@ -43,6 +53,10 @@ module RailsTemplate18f
 
       def generate_terraform_app
         `rails new tmp --template=spec/support/terraform_app_template.rb #{common_arguments}`
+      end
+
+      def generate_github_actions_app
+        `rails new tmp --template=spec/support/github_actions_app_template.rb #{common_arguments}`
       end
 
       def generate_storage_app

--- a/spec/support/generators.rb
+++ b/spec/support/generators.rb
@@ -29,6 +29,8 @@ module RailsTemplate18f
             generate_base_app
             system "mkdir", "-p", File.join(self.class.destination_path, ".github/workflows")
             system "touch", File.join(self.class.destination_path, ".github/workflows/deploy.yml")
+            system "mkdir", "-p", File.join(self.class.destination_path, "doc/compliance/oscal")
+            system "touch", File.join(self.class.destination_path, "/doc/compliance/oscal/trestle-config.yaml")
           }
         end
 

--- a/template.rb
+++ b/template.rb
@@ -69,6 +69,8 @@ if compliance_trestle_submodule && compliance_trestle_repo.blank?
   compliance_trestle = false
   compliance_trestle_submodule = false
 end
+# only ask about auditree if we're also using docker-trestle
+auditree = compliance_trestle ? yes?("Run compliance checks with auditree? (y/n)") : false
 
 terraform = yes?("Create terraform files for cloud.gov services? (y/n)")
 @cloud_gov_organization = ask("What is your cloud.gov organization name? (Leave blank to fill in later)")
@@ -456,6 +458,12 @@ if @circleci_pipeline
   register_announcement("CircleCI", <<~EOM)
     * Create project environment variables for deploy users as defined in the Deployment section of the README
   EOM
+end
+
+if auditree
+  after_bundle do
+    generate "rails_template18f:auditree"
+  end
 end
 
 # setup production credentials file


### PR DESCRIPTION
Adds experimental `rails_template18f:auditree` generator - relies on github actions and oscal generator both having been run already.